### PR TITLE
Fix relative path, see issue #46

### DIFF
--- a/download.php
+++ b/download.php
@@ -1,5 +1,7 @@
 <?php
-define('PHPWG_ROOT_PATH', '../../');
+$webRoot = $_SERVER['DOCUMENT_ROOT'];
+$webRootPath = $webRoot.'/';
+define('PHPWG_ROOT_PATH', $webRootPath);
 include(PHPWG_ROOT_PATH.'include/common.inc.php');
 
 check_status(ACCESS_GUEST);


### PR DESCRIPTION
Using absolute path fixes compatibility issue for containerised versions.