### PR TITLE
compatible with the directory installation method of https://github.com/linuxserver/docker-piwigo

### DIFF
--- a/download.php
+++ b/download.php
@@ -1,5 +1,11 @@
 <?php
-define('PHPWG_ROOT_PATH', '../../');
+//  check if the file /app/www/public/include/common.inc.php exists, 
+//  compatible with the directory installation method of https://github.com/linuxserver/docker-piwigo .
+if (file_exists('/app/www/public/include/common.inc.php')) {
+  define('PHPWG_ROOT_PATH', '/app/www/public/');
+} else {
+  define('PHPWG_ROOT_PATH', '../../');
+}
 include(PHPWG_ROOT_PATH.'include/common.inc.php');
 
 check_status(ACCESS_GUEST);

--- a/include/BatchDownloader.class.php
+++ b/include/BatchDownloader.class.php
@@ -959,6 +959,8 @@ SELECT SUM(filesize) AS total
     {
       $params = ImageStdParams::get_by_type($this->data['size']);
       $set['SIZE_INFO'] = $params->sizing->ideal_size[0].' x '.$params->sizing->ideal_size[1];
+    } else {
+      $set['SIZE_INFO'] = '';
     }
 
     return array_merge($set, $this->getNames());

--- a/language/zh_CN/plugin.lang.php
+++ b/language/zh_CN/plugin.lang.php
@@ -69,9 +69,9 @@ $lang['Warning: Only registered users can use Batch Downloader.'] = '警告：�
 $lang['What can be downloaded?'] = '可以下载什么？';
 $lang['No result'] = '没有结果';
 $lang['%d MB'] = '%d MB';
-$lang['Archive #%d (already downloaded)'] = '压缩文件 #%d(已经下载)';
+$lang['Archive #%d (already downloaded)'] = '压缩文件 #%d(已下载)';
 $lang['Archive #%d (pending)'] = '压缩文件 #%d(等待中)';
-$lang['Archive #%d (ready)'] = '压缩文件 #%d(准备中)';
+$lang['Archive #%d (ready)'] = '压缩文件 #%d(已准备)';
 $lang['Please wait, your download is being prepared. This page will automatically refresh when it is ready.'] = '请稍等，正在准备下载。准备完成后本页面将自动重载。';
 $lang['Preparation'] = '准备';
 $lang['Sorry, there is nothing to download. Some files may have been excluded because of <i title="Authorized types are : %s">filetype restrictions</i>.'] = '抱歉，没有可下载的文件。某些文件可能因为 <i title="被认可的类型 : %s">文件类型限制</i>而被排除了。';


### PR DESCRIPTION
1. compatible with the directory installation method of https://github.com/linuxserver/docker-piwigo

repair error log
```
2024/04/09 07:22:55 [error] 327#327: *621 FastCGI sent in stderr: "PHP message: PHP Warning:  include(../../include/common.inc.php): Failed to open stream: No such file or directory in /config/www/plugins/BatchDownloader/download.php on line 3; PHP message: PHP Warning:  include(): Failed opening '../../include/common.inc.php' for inclusion (include_path='.:/usr/share/php83') in /config/www/plugins/BatchDownloader/download.php on line 3; PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function check_status() in /config/www/plugins/BatchDownloader/download.php:5
Stack trace:
#0 {main}
  thrown in /config/www/plugins/BatchDownloader/download.php on line 5" while reading response header from upstream, client: 192.168.65.1, server: _, request: "GET /plugins/BatchDownloader/download.php?set_id=1&zip=1 HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "127.0.0.1:8065", referrer: "http://127.0.0.1:8065/index.php?/category/1&action=advdown_set&down_size=original"
```

2. set SIZE_INFO default value

Fix the display error when size is equal to original.

![image](https://github.com/Piwigo/Piwigo-BatchDownloader/assets/17667040/e8787531-d4cd-4735-8b10-ac176a0fe62b)

3. update translate


